### PR TITLE
Gen2024 removing int8 casts

### DIFF
--- a/src/clib/calc_tdust_1d_g.F
+++ b/src/clib/calc_tdust_1d_g.F
@@ -431,8 +431,8 @@ c             Tgr < 50 K (Omukai 2000).
             logalsp1(:) = logalsp(:,i)
        
             call interpolate_1D_g(
-     &           log10(tdust(i)), int8(gr_N), gr_Td, gr_dT,
-     &           int8(gr_Size), logalsp1, logkgr)
+     &           log10(tdust(i)), int(gr_N, 8), gr_Td, gr_dT,
+     &           int(gr_Size, 8), logalsp1, logkgr)
             kgr(i) = 10._DKIND**logkgr
 !!          write(*,*) 'fff', i, kgr(i)
 

--- a/src/clib/cool1d_multi_g.F
+++ b/src/clib/cool1d_multi_g.F
@@ -772,16 +772,16 @@
          lognhat = logH2I(i) - logdvdr(i)
 
          call interpolate_3D_g(
-     &     lognhat, logT(i), logH(i), int8(LH2_N), 
+     &     lognhat, logT(i), logH(i), int(LH2_N,8),
      &     LH2_D, LH2_dD, LH2_T, LH2_dT, LH2_H, LH2_dH,
-     &     int8(LH2_Size), LH2_L, log_Linv)
+     &     int(LH2_Size,8), LH2_L, log_Linv)
          L = 1.d1**(-log_Linv)
 
          if (icmbTfloor .eq. 1) then
          call interpolate_3D_g(
-     &     lognhat, logTcmb(i), logH(i), int8(LH2_N), 
+     &     lognhat, logTcmb(i), logH(i), int(LH2_N,8),
      &     LH2_D, LH2_dD, LH2_T, LH2_dT, LH2_H, LH2_dH,
-     &     int8(LH2_Size), LH2_L, log_Ginv)
+     &     int(LH2_Size,8), LH2_L, log_Ginv)
          G = 1.d1**(-log_Ginv)
          else
          G = tiny8
@@ -997,16 +997,16 @@ c     CIE H2 cooling using Yoshida et al. (2006)
          lognhat = logHDI(i) - logdvdr(i)
 
          call interpolate_3D_g(
-     &     lognhat, logT(i), logH(i), int8(LHD_N), 
+     &     lognhat, logT(i), logH(i), int(LHD_N,8),
      &     LHD_D, LHD_dD, LHD_T, LHD_dT, LHD_H, LHD_dH,
-     &     int8(LHD_Size), LHD_L, log_Linv)
+     &     int(LHD_Size,8), LHD_L, log_Linv)
          L = 1.d1**(-log_Linv)
 
          if (icmbTfloor .eq. 1) then
          call interpolate_3D_g(
-     &     lognhat, logTcmb(i), logH(i), int8(LHD_N), 
+     &     lognhat, logTcmb(i), logH(i), int(LHD_N,8),
      &     LHD_D, LHD_dD, LHD_T, LHD_dT, LHD_H, LHD_dH,
-     &     int8(LHD_Size), LHD_L, log_Ginv)
+     &     int(LHD_Size,8), LHD_L, log_Ginv)
          G = 1.d1**(-log_Ginv)
          else
          G = tiny8
@@ -1437,8 +1437,8 @@ c  new (correct) way: (april 4, 2007)
 
             !! primordial continuum opacity !!
             call interpolate_2D_g(
-     &        logrho(i), logT(i), int8(alphap_N), alphap_D, alphap_dD, 
-     &        alphap_T, alphap_dT, int8(alphap_Size), 
+     &        logrho(i), logT(i), int(alphap_N,8), alphap_D, alphap_dD,
+     &        alphap_T, alphap_dT, int(alphap_Size,8),
      &        alphap_Data, log_a)
               alpha(i) = 1.d1**log_a
          endif
@@ -1867,16 +1867,16 @@ c  new (correct) way: (april 4, 2007)
             lognhat = logCI(i) - logdvdr(i)
 
             call interpolate_3D_g(
-     &        lognhat, logT(i), logH(i), int8(LCI_N), 
+     &        lognhat, logT(i), logH(i), int(LCI_N,8),
      &        LCI_D, LCI_dD, LCI_T, LCI_dT, LCI_H, LCI_dH,
-     &        int8(LCI_Size), LCI_L, log_Linv)
+     &        int(LCI_Size,8), LCI_L, log_Linv)
             L = 1.d1**(-log_Linv)
       
             if (icmbTfloor .eq. 1) then
             call interpolate_3D_g(
-     &        lognhat, logTcmb(i), logH(i), int8(LCI_N), 
+     &        lognhat, logTcmb(i), logH(i), int(LCI_N,8),
      &        LCI_D, LCI_dD, LCI_T, LCI_dT, LCI_H, LCI_dH,
-     &        int8(LCI_Size), LCI_L, log_Ginv)
+     &        int(LCI_Size,8), LCI_L, log_Ginv)
             G = 1.d1**(-log_Ginv)
             else
             G = tiny8
@@ -1891,16 +1891,16 @@ c  new (correct) way: (april 4, 2007)
             lognhat = logCII(i) - logdvdr(i)
       
             call interpolate_3D_g(
-     &        lognhat, logT(i), logH(i), int8(LCII_N), 
+     &        lognhat, logT(i), logH(i), int(LCII_N,8),
      &        LCII_D, LCII_dD, LCII_T, LCII_dT, LCII_H, LCII_dH,
-     &        int8(LCII_Size), LCII_L, log_Linv)
+     &        int(LCII_Size,8), LCII_L, log_Linv)
             L = 1.d1**(-log_Linv)
       
             if (icmbTfloor .eq. 1) then
             call interpolate_3D_g(
-     &        lognhat, logTcmb(i), logH(i), int8(LCII_N), 
+     &        lognhat, logTcmb(i), logH(i), int(LCII_N,8),
      &        LCII_D, LCII_dD, LCII_T, LCII_dT, LCII_H, LCII_dH,
-     &        int8(LCII_Size), LCII_L, log_Ginv)
+     &        int(LCII_Size,8), LCII_L, log_Ginv)
             G = 1.d1**(-log_Ginv)
             else
             G = tiny8
@@ -1915,16 +1915,16 @@ c  new (correct) way: (april 4, 2007)
             lognhat = logOI(i) - logdvdr(i)
       
             call interpolate_3D_g(
-     &        lognhat, logT(i), logH(i), int8(LOI_N), 
+     &        lognhat, logT(i), logH(i), int(LOI_N,8),
      &        LOI_D, LOI_dD, LOI_T, LOI_dT, LOI_H, LOI_dH,
-     &        int8(LOI_Size), LOI_L, log_Linv)
+     &        int(LOI_Size,8), LOI_L, log_Linv)
             L = 1.d1**(-log_Linv)
       
             if (icmbTfloor .eq. 1) then
             call interpolate_3D_g(
-     &        lognhat, logTcmb(i), logH(i), int8(LOI_N), 
+     &        lognhat, logTcmb(i), logH(i), int(LOI_N,8),
      &        LOI_D, LOI_dD, LOI_T, LOI_dT, LOI_H, LOI_dH,
-     &        int8(LOI_Size), LOI_L, log_Ginv)
+     &        int(LOI_Size,8), LOI_L, log_Ginv)
             G = 1.d1**(-log_Ginv)
             else
             G = tiny8
@@ -1941,16 +1941,16 @@ c  new (correct) way: (april 4, 2007)
             lognhat = logCO(i) - logdvdr(i)
       
             call interpolate_3D_g(
-     &        lognhat, logT(i), logH2(i), int8(LCO_N), 
+     &        lognhat, logT(i), logH2(i), int(LCO_N,8),
      &        LCO_D, LCO_dD, LCO_T, LCO_dT, LCO_H, LCO_dH,
-     &        int8(LCO_Size), LCO_L, log_Linv)
+     &        int(LCO_Size,8), LCO_L, log_Linv)
             L = 1.d1**(-log_Linv)
       
             if (icmbTfloor .eq. 1) then
             call interpolate_3D_g(
-     &        lognhat, logTcmb(i), logH2(i), int8(LCO_N), 
+     &        lognhat, logTcmb(i), logH2(i), int(LCO_N,8),
      &        LCO_D, LCO_dD, LCO_T, LCO_dT, LCO_H, LCO_dH,
-     &        int8(LCO_Size), LCO_L, log_Ginv)
+     &        int(LCO_Size,8), LCO_L, log_Ginv)
             G = 1.d1**(-log_Ginv)
             else
             G = tiny8
@@ -1965,16 +1965,16 @@ c  new (correct) way: (april 4, 2007)
             lognhat = logOH(i) - logdvdr(i)
       
             call interpolate_3D_g(
-     &        lognhat, logT(i), logH2(i), int8(LOH_N), 
+     &        lognhat, logT(i), logH2(i), int(LOH_N,8),
      &        LOH_D, LOH_dD, LOH_T, LOH_dT, LOH_H, LOH_dH,
-     &        int8(LOH_Size), LOH_L, log_Linv)
+     &        int(LOH_Size,8), LOH_L, log_Linv)
             L = 1.d1**(-log_Linv)
       
             if (icmbTfloor .eq. 1) then
             call interpolate_3D_g(
-     &        lognhat, logTcmb(i), logH2(i), int8(LOH_N), 
+     &        lognhat, logTcmb(i), logH2(i), int(LOH_N,8),
      &        LOH_D, LOH_dD, LOH_T, LOH_dT, LOH_H, LOH_dH,
-     &        int8(LOH_Size), LOH_L, log_Ginv)
+     &        int(LOH_Size,8), LOH_L, log_Ginv)
             G = 1.d1**(-log_Ginv)
             else
             G = tiny8
@@ -1989,16 +1989,16 @@ c  new (correct) way: (april 4, 2007)
             lognhat = logH2O(i) - logdvdr(i)
       
             call interpolate_3D_g(
-     &        lognhat, logT(i), logH2(i), int8(LH2O_N), 
+     &        lognhat, logT(i), logH2(i), int(LH2O_N,8),
      &        LH2O_D, LH2O_dD, LH2O_T, LH2O_dT, LH2O_H, LH2O_dH,
-     &        int8(LH2O_Size), LH2O_L, log_Linv)
+     &        int(LH2O_Size,8), LH2O_L, log_Linv)
             L = 1.d1**(-log_Linv)
       
             if (icmbTfloor .eq. 1) then
             call interpolate_3D_g(
-     &        lognhat, logTcmb(i), logH2(i), int8(LH2O_N), 
+     &        lognhat, logTcmb(i), logH2(i), int(LH2O_N,8),
      &        LH2O_D, LH2O_dD, LH2O_T, LH2O_dT, LH2O_H, LH2O_dH,
-     &        int8(LH2O_Size), LH2O_L, log_Ginv)
+     &        int(LH2O_Size,8), LH2O_L, log_Ginv)
             G = 1.d1**(-log_Ginv)
             else
             G = tiny8

--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -2619,7 +2619,7 @@ C                 endif
      &      , tAl2O3(in) 
      &      , treforg(in) , tvolorg(in) , tH2Oice(in)
 !     tabulate h2 formation rate
-      integer d_N(2), d_Size
+      integer*8 d_N(2), d_Size
       real*8  d_dTd, d_dTg
       real*8  d_Td(ndratec),  d_Tg(nratec)
       integer idratec, iratec
@@ -2989,8 +2989,8 @@ C                 endif
          else ! idspecies
 
 !        create table for interpolation
-         d_N(1) = ndratec
-         d_N(2) = nratec
+         d_N(1) = int(ndratec, 8)
+         d_N(2) = int(nratec, 8)
          d_Size = d_N(1) * d_N(2)
          d_dTd = d_dlogtem
          d_dTg = dlogtem
@@ -3009,12 +3009,12 @@ C                 endif
                   if (idspecies .gt. 0) then
                   d_logtem(i) = log(tdust(i))
                   call interpolate_2D_g(
-     &              d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd, 
-     &              d_Tg, d_dTg, int8(d_Size), h2dustSa, h2MgSiO3 )
+     &              d_logtem(i), logtem(i), d_N, d_Td, d_dTd, 
+     &              d_Tg, d_dTg, d_Size, h2dustSa, h2MgSiO3 )
                  
                   call interpolate_2D_g(
-     &              d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd, 
-     &              d_Tg, d_dTg, int8(d_Size), h2dustCa, h2AC     )
+     &              d_logtem(i), logtem(i), d_N, d_Td, d_dTd, 
+     &              d_Tg, d_dTg, d_Size, h2dustCa, h2AC     )
 
                      h2dust(i) = h2MgSiO3   * sgMgSiO3  (i)
      &                         + h2AC       * sgAC      (i)
@@ -3042,72 +3042,72 @@ C                 endif
                   if (idspecies .gt. 0) then
                      d_logtem(i) = log(tMgSiO3  (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2MgSiO3  )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2MgSiO3  )
                  
                      d_logtem(i) = log(tAC      (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustCa, h2AC      )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustCa, h2AC      )
                   endif
 
                   if (idspecies .gt. 1) then
                      d_logtem(i) = log(tSiM     (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd, 
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2SiM     )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd, 
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2SiM     )
              
                      d_logtem(i) = log(tFeM     (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2FeM     )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2FeM     )
                  
                      d_logtem(i) = log(tMg2SiO4 (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2Mg2SiO4 )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2Mg2SiO4 )
                  
                      d_logtem(i) = log(tFe3O4   (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2Fe3O4   )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2Fe3O4   )
                  
                      d_logtem(i) = log(tSiO2D   (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2SiO2D   )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2SiO2D   )
                  
                      d_logtem(i) = log(tMgO     (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2MgO     )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2MgO     )
                  
                      d_logtem(i) = log(tFeS     (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2FeS     )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2FeS     )
                  
                      d_logtem(i) = log(tAl2O3   (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2Al2O3   )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2Al2O3   )
                   endif
 
                   if (idspecies .gt. 2) then
                      d_logtem(i) = log(treforg  (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2reforg  )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2reforg  )
                  
                      d_logtem(i) = log(tvolorg  (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd,
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2volorg  )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd,
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2volorg  )
                  
                      d_logtem(i) = log(tH2Oice  (i))
                      call interpolate_2D_g(
-     &                 d_logtem(i), logtem(i), int8(d_N), d_Td, d_dTd, 
-     &                 d_Tg, d_dTg, int8(d_Size), h2dustSa, h2H2Oice  )
+     &                 d_logtem(i), logtem(i), d_N, d_Td, d_dTd, 
+     &                 d_Tg, d_dTg, d_Size, h2dustSa, h2H2Oice  )
                   endif
               
                   if (idspecies .gt. 0) then

--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -3146,8 +3146,8 @@ C                 endif
 
                if (idspecies .gt. 0) then
                call interpolate_1D_g(
-     &              logtem(i), int8(nratec), d_Tg, d_dTg,
-     &              int8(nratec), grogra, kd)
+     &              logtem(i), int(nratec, 8), d_Tg, d_dTg,
+     &              int(nratec, 8), grogra, kd)
             
                kdMgSiO3  (i) = kd * sgMgSiO3  (i) * d(i,j,k)
      &          * min( Mg  (i,j,k) / 24._DKIND**1.5_DKIND


### PR DESCRIPTION
This is VERY simple PR that replaces the [gfortran-extension routine](https://gcc.gnu.org/onlinedocs/gfortran/INT8.html), `int8(arg)`, with the equivalent [standard routine](https://gcc.gnu.org/onlinedocs/gfortran/INT.html) `int(arg,8)`. This was creating problems for some of the scripts that I had written to help transcribe from fortran

Inside of `lookup_cool_rates1d_g`, I was able to eliminate a number of casts. Previously, we repeatedly cast 2 local variables `d_N` and `d_Size`. Now we just declare the local `d_N` and `d_Size` variables to have the correct type.

I locally tested and confirmed that all tests pass after these changes. 

Maybe we should make the gen2024 branch a branch on the grackle repository so that we can properly run CI on PRs?

> [!NOTE]
> The `test_models.py` suite of tests seem flaky. Usually they pass, but a handful of them fail (usually, they'll pass after I relaunch them). This is an issue I observed in the gen2024 branch even without these changes. Thus, I'm extremely confident that these changes NOT are causing that issue. (I suspect we are allocating memory somewhere and not properly initializing it -- hopefully this becomes more apparent as we go along)