### PR TITLE
Standardize parameter declaration

### DIFF
--- a/src/clib/calc_grain_size_increment_1d.F
+++ b/src/clib/calc_grain_size_increment_1d.F
@@ -457,9 +457,8 @@
       real*8 dsp0, SN_sgsp, SN_kpsp
       real*8 SN_dsp0(SN0_N), SN_nsp0(SN0_N)
       real*8 drsp(in)
-      real*8 pi, mh
-      parameter (pi = pi_val)
-      parameter (mh = mass_h)
+      real*8, parameter :: pi = pi_val
+      real*8, parameter :: mh = mass_h
 !     debug
       real*8 SN_dsp(SN0_N), SN_msp(SN0_N), dsp1
       integer iTd, iTd0
@@ -649,8 +648,7 @@
       real*8 q, r, m
       real*8 th
       real*8 s,t
-      real*8 pi
-      parameter (pi = pi_val)
+      real*8, parameter :: pi = pi_val
 
       q = (a*a - 3.d0*b)/9.d0
       r = (2.d0*a*a*a - 9.d0*a*b + 27.d0*c)/54.d0

--- a/src/clib/calc_tdust_1d_g.F
+++ b/src/clib/calc_tdust_1d_g.F
@@ -65,18 +65,17 @@
 !  Parameters
 
       integer idspecies
-      real*8 t_subl
-      parameter(t_subl = 1.5e3_DKIND) ! grain sublimation temperature
-      real*8 radf
-      parameter(radf = 4._DKIND * sigma_sb)
-      real*8 kgr1
-      parameter(kgr1 = 4.0e-4_DKIND / 0.009387d0)
+      ! grain sublimation temperature
+      real*8, parameter :: t_subl = 1.5e3_DKIND
+      real*8, parameter :: radf = 4._DKIND * sigma_sb
+      real*8, parameter :: kgr1 = 4.0e-4_DKIND / 0.009387d0
          !! should be normalized with local fgr. [GC20200701]
-      real*8 tol, bi_tol, minpert, gamma_isrf(in)
-      parameter(tol = 1.e-5_DKIND, bi_tol = 1.e-3_DKIND, 
-     &     minpert = 1.e-10_DKIND)
-      integer itmax, bi_itmax
-      parameter(itmax = 50, bi_itmax = 30)
+      real*8 gamma_isrf(in)
+      real*8, parameter :: tol = 1.e-5_DKIND
+      real*8, parameter :: bi_tol = 1.e-3_DKIND
+      real*8, parameter :: minpert = 1.e-10_DKIND
+      integer, parameter :: itmax = 50
+      integer, parameter :: bi_itmax = 30
 
 !  Locals
 
@@ -384,9 +383,8 @@ c               ERROR_MESSAGE
 
 !  Parameters
 
-      real*8 kgr1, kgr200
-      parameter(kgr1 = 4.0e-4_DKIND / 0.009387d0
-     &        , kgr200 = 16.0_DKIND / 0.009387d0)
+      real*8, parameter :: kgr1 = 4.0e-4_DKIND / 0.009387d0
+      real*8, parameter :: kgr200 = 16.0_DKIND / 0.009387d0
          !! should be normalized with local fgr. [GC20200701]
          !! This value is valid only for Td < 50 K (Omukai 2000).
 
@@ -498,8 +496,7 @@ c             Tgr < 50 K (Omukai 2000).
 
 !  Parameters
 
-      real*8 radf
-      parameter(radf = 4._DKIND * sigma_sb)
+      real*8, parameter :: radf = 4._DKIND * sigma_sb
 
 !  Locals
 

--- a/src/clib/calc_tdust_3d_g.F
+++ b/src/clib/calc_tdust_3d_g.F
@@ -187,8 +187,7 @@
 
 !  Parameters
 
-      real*8 mh
-      parameter (mh = mass_h)
+      real*8, parameter :: mh = mass_h
 
 !  Locals
 

--- a/src/clib/calc_temp1d_cloudy_g.F
+++ b/src/clib/calc_temp1d_cloudy_g.F
@@ -82,10 +82,9 @@
 
 !  Parameters
 
-      integer ti_max
-      real*8 mu_metal
-      parameter (mu_metal = 16._DKIND)    ! approx. mean molecular weight of metals
-      parameter (ti_max = 20)
+      ! approx. mean molecular weight of metals
+      real*8, parameter :: mu_metal = 16._DKIND
+      integer, parameter :: ti_max = 20
 
 !  Locals
 

--- a/src/clib/calc_temp_cloudy_g.F
+++ b/src/clib/calc_temp_cloudy_g.F
@@ -86,8 +86,7 @@
 
 !  Parameters
 
-      real*8 mh
-      parameter (mh = mass_h)
+      real*8, parameter :: mh = mass_h
 
 !  Locals
 

--- a/src/clib/cool1d_multi_g.F
+++ b/src/clib/cool1d_multi_g.F
@@ -208,11 +208,10 @@
 
 !  Parameters
 
-      integer ti_max
-      real*8 mh, mu_metal
-      parameter (mh = mass_h)      !DPC
-      parameter (mu_metal = 16._DKIND)    ! approx. mean molecular weight of metals
-      parameter (ti_max = 20)
+      real*8, parameter :: mh = mass_h      !DPC
+      ! approx. mean molecular weight of metals
+      real*8, parameter :: mu_metal = 16._DKIND
+      integer, parameter :: ti_max = 20
 
 !  Locals
 

--- a/src/clib/lookup_cool_rates0d.F
+++ b/src/clib/lookup_cool_rates0d.F
@@ -249,21 +249,18 @@ c -------------------------------------------------------------------
 
 !  Parameters
 
-      integer itmax
-      parameter (itmax = 10000)
+      integer, parameter :: itmax = 10000
 
 #ifdef CONFIG_BFLOAT_4
-      R_PREC tolerance
-      parameter (tolerance = 1.0e-05_RKIND)
+      R_PREC, parameter :: tolerance = 1.0e-05_RKIND
 #endif
 
 #ifdef CONFIG_BFLOAT_8
-      R_PREC tolerance
-      parameter (tolerance = 1.0e-10_RKIND)
+      R_PREC, parameter :: tolerance = 1.0e-10_RKIND
 #endif
 
-      real*8 mh, pi
-      parameter (mh = mass_h, pi = pi_val)
+      real*8, parameter :: mh = mass_h
+      real*8, parameter :: pi = pi_val
 
 !  Locals
 

--- a/src/clib/lookup_cool_rates0d.F
+++ b/src/clib/lookup_cool_rates0d.F
@@ -251,11 +251,9 @@ c -------------------------------------------------------------------
 
       integer, parameter :: itmax = 10000
 
-#ifdef CONFIG_BFLOAT_4
+#ifdef GRACKLE_FLOAT_4
       R_PREC, parameter :: tolerance = 1.0e-05_RKIND
-#endif
-
-#ifdef CONFIG_BFLOAT_8
+#else
       R_PREC, parameter :: tolerance = 1.0e-10_RKIND
 #endif
 

--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -445,9 +445,7 @@
 
 #ifdef GRACKLE_FLOAT_4
       R_PREC, parameter :: tolerance = 1.0e-05_RKIND
-#endif
-
-#ifdef GRACKLE_FLOAT_8
+#else
       R_PREC, parameter :: tolerance = 1.0e-10_RKIND
 #endif
 

--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -444,17 +444,15 @@
 !  Parameters
 
 #ifdef GRACKLE_FLOAT_4
-      R_PREC tolerance
-      parameter (tolerance = 1.0e-05_RKIND)
+      R_PREC, parameter :: tolerance = 1.0e-05_RKIND
 #endif
 
 #ifdef GRACKLE_FLOAT_8
-      R_PREC tolerance
-      parameter (tolerance = 1.0e-10_RKIND)
+      R_PREC, parameter :: tolerance = 1.0e-10_RKIND
 #endif
 
-      real*8 mh, pi
-      parameter (mh = mass_h, pi = pi_val)
+      real*8, parameter :: mh = mass_h
+      real*8, parameter :: pi = pi_val
 
 !  Locals
 
@@ -2517,9 +2515,9 @@ C                 endif
 
 !     Parameters
 
-      real*8 everg, e24, e26
-      parameter(everg = ev2erg, e24 = 13.6_DKIND,
-     &     e26 = 24.6_DKIND)
+      real*8, parameter :: everg = ev2erg
+      real*8, parameter :: e24 = 13.6_DKIND
+      real*8, parameter :: e26 = 24.6_DKIND
 
 !     locals
 
@@ -2596,8 +2594,8 @@ C                 endif
       real*8  d_Td(ndratec),  d_Tg(nratec)
       integer idratec, iratec
       real*8  kd
-      real*8 fh, mh
-      parameter (mh = mass_h)      !DPC
+      real*8 fh
+      real*8, parameter :: mh = mass_h      !DPC
 
 !     locals for H2 self-shielding as WG+19
 


### PR DESCRIPTION
Previously, there were 2 different ways to declare parameters scattered throughout the codebase. This patch standardizes on a single approach that is easier to transcribe.

To be explicit, I changed snippets like

```Fortran
      real*8 pi, mh
      parameter (pi = pi_val)
      parameter (mh = mass_h)
```
to now read
```Fortran
      real*8, parameter :: pi = pi_val
      real*8, parameter :: mh = mass_h
```

I have confirmed that the tests still pass with the changes introduced by this PR

EDIT: I also added a commit that standardized the way we set precision-dependent tolerance. Again I confirmed that tests pass