### PR TITLE
Porting over various physical constants defined in the Fortran

### DIFF
--- a/src/clib/grackle_macros.h
+++ b/src/clib/grackle_macros.h
@@ -13,6 +13,9 @@
 
 #ifndef __GRACKLE_MACROS_H_
 #define __GRACKLE_MACROS_H_
+
+#include "grackle_float.h"
+
 /***********************************************************************
 /  
 / MACRO DEFINITIONS AND PARAMETERS
@@ -53,6 +56,30 @@
 #define PFORTRAN_NAME(NAME) NAME##_c
 #else
 #define PFORTRAN_NAME(NAME) FORTRAN_NAME(NAME)
+#endif
+
+/* Function macro for gr_float literal */
+
+/// @def GRFLOAT_C(DBL_LITERAL)
+/// @brief expands to a a floating point literal having the value specified by
+///     it argument and the type `gr_float`. The argument must be a literal
+///     with the type `double`
+///
+/// @par More details
+/// This is directly analogous to the `INT32_C(ARG)` or `INTMAX_C(ARG)` macros
+/// defined by the standard <stdint.h> header, but it is designed for
+/// `gr_float` than rather fixed-size integer types. In more detail:
+/// - if `sizeof(gr_float) == sizeof(float)` the macro expands to the input
+///   argument with the `f` suffix.
+/// - otherwise, the macro expands to the input argument
+///
+/// @par Concrete Example
+/// The snippet, `GRFLOAT_C(1.0)` expands to either `1.0f` or `1.0`.
+#ifdef GRACKLE_FLOAT_4
+  #define INNER_CONCAT_(A, B) A ## B
+  #define GRFLOAT_C(DBL_LITERAL) ( INNER_CONCAT_(DBL_LITERAL, f) )
+#elif defined(GRACKLE_FLOAT_8)
+  #define GRFLOAT_C(DBL_LITERAL) ( DBL_LITERAL )
 #endif
 
 /* HDF5 definitions */
@@ -111,6 +138,13 @@
 #ifndef huge
 #define huge 1.0e20
 #endif
+
+// the following 4 are explicitly defined to always match the values used by
+// the fortran layer (in the future, maybe we can consolidate?)
+#define tiny_fortran_val GRFLOAT_C(1.0e-20)
+#define huge_fortran_val GRFLOAT_C(1.0e20)
+#define tiny8 1.0e-40
+#define huge8 1.0e40
 
 /* Macro definitions (things C should have) */
 

--- a/src/clib/phys_constants.h
+++ b/src/clib/phys_constants.h
@@ -22,7 +22,20 @@
 /
 / Note: CGS units
 /
+/ Historically, all constants in this file always expanded to floating point
+/ values of type `double`.
+/ - In constrast, the "phys_const.def" fortran header always defined
+/   macro-constants that expand to floating-point values of type `gr_float`.
+/ - To aide with transcribing code from Fortran to C/C++ we have
+/   defined versions of most constants in this file that expand to constant
+/   of type `gr_float`. These constants have the `_grflt` suffix.
+/ - In the future, it would be nice to do away with the alternative versions
+/   of these constants
+/
 *********************************************************************/
+
+#include "grackle_float.h"
+#include "grackle_macros.h" // GRFLOAT_C
 
 /* Physics constants */
 
@@ -31,19 +44,28 @@
 /* Boltzmann's constant [cm2gs-2K-1] or [ergK-1] */
 
 #define kboltz                          1.3806504e-16
+#define kboltz_grflt                    GRFLOAT_C(kboltz)
 
 /* Mass of hydrogen [g] */
 
 #define mh                              1.67262171e-24   
+#define mh_grflt                        GRFLOAT_C(mh)
 
 /* Mass of an electron [g] */
 
 #define me                              9.10938215e-28
+#define me_grflt                        GRFLOAT_C(me)
 
 /* Pi */
 
 #define pi                              3.14159265358979323846
 
+// the following matches the value of `pi_val` from "phys_consts.def"
+#ifdef GRACKLE_FLOAT_4
+  #define pi_fortran_val 3.14159265f
+#else
+  #define pi_fortran_val 3.141592653589793
+#endif
 
 /************************************************/
 
@@ -54,19 +76,59 @@
 /* Speed of light [cms-1] */ 
 
 #define clight                          2.99792458e10
+#define clight_grflt                    GRFLOAT_C(clight)
 
 /* Gravitational constant [cm3g-1s-2]*/
 
 #define GravConst                       6.67428e-8
+#define GravConst_grflt                 GRFLOAT_C(GravConst)
 
 /* Solar mass [g] */
 
 #define SolarMass                       1.9891e33
+#define SolarMass_grflt                 GRFLOAT_C(SolarMass)
 
 /* Megaparsec [cm] */
 
 #define Mpc                             3.0857e24
+#define Mpc_grflt                       GRFLOAT_C(Mpc)
+
 #define kpc                             3.0857e21
+#define kpc_grflt                       GRFLOAT_C(kpc)
+
 #define pc                              3.0857e18
+#define pc_grflt                        GRFLOAT_C(pc)
+
+/************************************************/
+
+/* Miscellaneous values adopted from phys_const.def */
+
+/************************************************/
+
+#define hplanck_grflt  GRFLOAT_C(6.6260693e-27)
+#define ev2erg_grflt   GRFLOAT_C(1.60217653e-12)
+#define sigma_sb_grflt GRFLOAT_C(5.670373e-5)
+
+/************************************************/
+
+/* dust constants (taken from dust_const.def) */
+
+/************************************************/
+
+/* (we may want to relocate these to a different file in the future) */
+
+#define sSiM      2.34118e0
+#define sFeM      7.95995e0
+#define sMg2SiO4  3.22133e0
+#define sMgSiO3   3.20185e0
+#define sFe3O4    5.25096e0
+#define sAC       2.27949e0
+#define sSiO2D    2.66235e0
+#define sMgO      3.58157e0
+#define sFeS      4.87265e0
+#define sAl2O3    4.01610e0
+#define sreforg   1.5e0
+#define svolorg   1.0e0
+#define sH2Oice   0.92e0
 
 #endif


### PR DESCRIPTION
A lot of the physical constants in the C and Fortran layers are defined in slightly different ways. This commit seeks to make all of the Fortran constants in one form or another in a way that won't produce name-collisions with the existing constants defined in C.

The biggest difference for most constants is the precision of the constant.

In the future, I would like to reduce the number of variants of constants, but that will be easier after we finish the conversion.