### PR TITLE
fwd `iH2shieldcustom` & `f_shield_custom` args

### DIFF
--- a/src/clib/lookup_cool_rates0d.F
+++ b/src/clib/lookup_cool_rates0d.F
@@ -124,6 +124,7 @@
      &             , imp_eng
      &             , idissHDI, kdissHDI, iionZ, kphCI, kphOI
      &             , idissZ, kdissCO, kdissOH, kdissH2O, iuseH2shield
+     &             , iH2shieldcustom, f_shield_custom
      &         )
 
 c -------------------------------------------------------------------
@@ -139,7 +140,7 @@ c -------------------------------------------------------------------
      &        igammah, ih2optical, iciecool, ih2cr, ihdcr, ithreebody,
      &        ndratec, clnew, iVheat, iMheat, iTfloor,
      &        iH2shield, iradshield,
-     &        iradtrans, irt_honly, iisrffield
+     &        iradtrans, iH2shieldcustom, irt_honly, iisrffield
      &       ,imchem, igrgr, ipcont
       MASK_TYPE itmask, itmask_metal, anydust
 
@@ -179,6 +180,10 @@ c -------------------------------------------------------------------
 !  Interstellar radiation field for dust heating
 
       R_PREC  isrf_habing
+
+!  Custom H2 shielding factor
+
+      R_PREC f_shield_custom
 
 !  Cooling tables (coolings rates as a function of temperature)
 
@@ -688,6 +693,7 @@ c -------------------------------------------------------------------
      &              , tSiM, tFeM, tMg2SiO4, tMgSiO3, tFe3O4
      &              , tAC, tSiO2D, tMgO, tFeS, tAl2O3
      &              , treforg, tvolorg, tH2Oice, iuseH2shield
+     &              , iH2shieldcustom, f_shield_custom
      &      )
 
 !           Compute dedot and HIdot, the rates of change of de and HI

--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -969,6 +969,7 @@ c     chunit = (1.60218e-12_DKIND)/(2._DKIND*uvel*uvel*mh)   ! 1 eV per H2 forme
      &              , tSiM, tFeM, tMg2SiO4, tMgSiO3, tFe3O4
      &              , tAC, tSiO2D, tMgO, tFeS, tAl2O3
      &              , treforg, tvolorg, tH2Oice, iuseH2shield
+     &              , iH2shieldcustom, f_shield_custom
      &      )
 
 !           Compute dedot and HIdot, the rates of change of de and HI
@@ -1329,7 +1330,8 @@ c     chunit = (1.60218e-12_DKIND)/(2._DKIND*uvel*uvel*mh)   ! 1 eV per H2 forme
      &                gasgr2a, gamma_isrf2a, grogra, idissHDI,
      &                kdissHDI, iionZ, kphCI, kphOI, idissZ, kdissCO,
      &                kdissOH, kdissH2O, iuseH2shield, iisrffield,
-     &                isrf_habing, ierror, j, k, iter, dom, comp1,
+     &                isrf_habing, iH2shieldcustom, f_shield_custom,
+     &                ierror, j, k, iter, dom, comp1,
      &                comp2, coolunit, tbase1, xbase1, chunit, dx_cgs,
      &                c_ljeans, indixe, t1, t2, logtem, tdef, dtit,
      &                p2d, tgas, tgasold, tdust, metallicity, dust2gas,
@@ -1808,6 +1810,7 @@ C                 endif
      &              , tSiM, tFeM, tMg2SiO4, tMgSiO3, tFe3O4
      &              , tAC, tSiO2D, tMgO, tFeS, tAl2O3
      &              , treforg, tvolorg, tH2Oice, iuseH2shield
+     &              , iH2shieldcustom, f_shield_custom
      &      )
 ! -------------------------------------------------------------------
 

--- a/src/clib/step_rate_newton_raphson.F
+++ b/src/clib/step_rate_newton_raphson.F
@@ -75,7 +75,8 @@
      &                gasgr2a, gamma_isrf2a, grogra, idissHDI,
      &                kdissHDI, iionZ, kphCI, kphOI, idissZ, kdissCO,
      &                kdissOH, kdissH2O, iuseH2shield, iisrffield,
-     &                isrf_habing, ierror, j, k, iter, dom, comp1,
+     &                isrf_habing, iH2shieldcustom, f_shield_custom,
+     &                ierror, j, k, iter, dom, comp1,
      &                comp2, coolunit, tbase1, xbase1, chunit, dx_cgs,
      &                c_ljeans, indixe, t1, t2, logtem, tdef, dtit,
      &                p2d, tgas, tgasold, tdust, metallicity, dust2gas,
@@ -104,7 +105,7 @@
      &        idustfield, idustrec, igammah, ih2optical, iciecool,
      &        ithreebody, ih2cr, ihdcr, ndratec, clnew, iVheat, iMheat,
      &        iTfloor, iH2shield, iradshield, iradtrans, irt_honly,
-     &        imchem, igrgr, ipcont, iisrffield
+     &        imchem, igrgr, ipcont, iisrffield, iH2shieldcustom
 
       real*8 aye, temstart, temend, gamma, utim, uxyz, uaye, urho,
      &       utem, fh, z_solar, fgr, dtemstart, dtemend, clEleFra,
@@ -159,6 +160,10 @@
 !  Interstellar radiation field for dust heating
 
       R_PREC  isrf_habing(in,jn,kn)
+
+!  Custom H2 shielding factor
+
+      R_PREC f_shield_custom(in, jn, kn)
 
 !  Cooling tables (coolings rates as a function of temperature)
 
@@ -681,7 +686,7 @@
      & , imp_eng(i)
      & , idissHDI, kdissHDI(i,j,k), iionZ, kphCI(i,j,k), kphOI(i,j,k)
      & , idissZ, kdissCO(i,j,k), kdissOH(i,j,k), kdissH2O(i,j,k)
-     & , iuseH2shield
+     & , iuseH2shield, iH2shieldcustom, f_shield_custom(i,j,k)
      &   )
 
                     do jsp = 1, nsp
@@ -817,7 +822,7 @@
      & , imp_eng(i)
      & , idissHDI, kdissHDI(i,j,k), iionZ, kphCI(i,j,k), kphOI(i,j,k)
      & , idissZ, kdissCO(i,j,k), kdissOH(i,j,k), kdissH2O(i,j,k)
-     & , iuseH2shield
+     & , iuseH2shield, iH2shieldcustom, f_shield_custom(i,j,k)
      &   )
 
                       do isp = 1, nsp


### PR DESCRIPTION
We need to pass `iH2shieldcustom` and `f_shield_custom` as arguments to `lookup_cool_rates1d_g`.

These variables already had type declarations within `lookup_cool_rates1d_g`, but they because they were passed as part of the argument list, they were previously locally allocated within the function and used without initialization. This is all fixed now

(I confirmed that all tests pass with this PR)