### PR TITLE
Gen2024 uninitialized err

### DIFF
--- a/src/clib/cool1d_multi_g.F
+++ b/src/clib/cool1d_multi_g.F
@@ -1117,41 +1117,46 @@ c  new (correct) way: (april 4, 2007)
 
       endif
 
-!     Calculate dust to gas ratio
+!     Calculate dust to gas ratio AND interstellar radiation field
+!     -> an earlier version of this logic would store values @ indices
+!        where `itmask_metal(i) .ne. MASK_FALSE`
+!     -> this was undesirable, b/c these quantities are required for
+!        photo-electric heating, which can occur when
+!        `itmask_metal(i) .eq. MASK_FALSE` (we can revisit this choice
+!        later). Moreover, in most cases, these calculations will be
+!        faster when there is no branching
 
       if ((anydust .ne. MASK_FALSE) .or. (igammah .gt. 0)) then
          if (idustfield .gt. 0) then
             do i = is+1, ie+1
-               if ( itmask_metal(i) .ne. MASK_FALSE ) then
+               ! REMINDER: use of `itmask` over `itmask_metal` is
+               !   currently required by Photo-electric heating
+               if (itmask(i) .ne. MASK_FALSE) then
+                  ! it may be faster to remove this branching
                   dust2gas(i) = dust(i,j,k) / d(i,j,k)
                endif
             enddo
          else
             do i = is+1, ie+1
-               if ( itmask_metal(i) .ne. MASK_FALSE ) then
-                  dust2gas(i) = fgr * metallicity(i)
-               endif
+               dust2gas(i) = fgr * metallicity(i)
             enddo
          endif
       endif
-
-!     Calculate interstellar radiation field
 
       if ((anydust .ne. MASK_FALSE) .or. (igammah .gt. 1)) then
          if (iisrffield .gt. 0) then
             do i = is+1, ie+1
-               if ( itmask_metal(i) .ne. MASK_FALSE ) then
-                  myisrf(i) = isrf_habing(i,j,k)
-               endif
+               myisrf(i) = isrf_habing(i,j,k)
             enddo
          else
             do i = is+1, ie+1
-               if ( itmask_metal(i) .ne. MASK_FALSE ) then
-                  myisrf(i) = isrf
-               endif
+               myisrf(i) = isrf
             enddo
          endif
       endif
+
+!     Calculate heating from interstellar radiation field
+!     -> this is ONLY used when `itmask_metal .eq. MASK_TRUE`
 
       if ((anydust .ne. MASK_FALSE) .or. (igammah .gt. 1)) then
       do i = is+1, ie+1

--- a/src/clib/lookup_cool_rates0d.F
+++ b/src/clib/lookup_cool_rates0d.F
@@ -124,6 +124,7 @@
      &             , imp_eng
      &             , idissHDI, kdissHDI, iionZ, kphCI, kphOI
      &             , idissZ, kdissCO, kdissOH, kdissH2O, iuseH2shield
+     &             , iH2shieldcustom, f_shield_custom
      &         )
 
 c -------------------------------------------------------------------
@@ -139,7 +140,7 @@ c -------------------------------------------------------------------
      &        igammah, ih2optical, iciecool, ih2cr, ihdcr, ithreebody,
      &        ndratec, clnew, iVheat, iMheat, iTfloor,
      &        iH2shield, iradshield,
-     &        iradtrans, irt_honly, iisrffield
+     &        iradtrans, iH2shieldcustom, irt_honly, iisrffield
      &       ,imchem, igrgr, ipcont
       MASK_TYPE itmask, itmask_metal, anydust
 
@@ -179,6 +180,10 @@ c -------------------------------------------------------------------
 !  Interstellar radiation field for dust heating
 
       R_PREC  isrf_habing
+
+!  Custom H2 shielding factor
+
+      R_PREC f_shield_custom
 
 !  Cooling tables (coolings rates as a function of temperature)
 
@@ -688,6 +693,7 @@ c -------------------------------------------------------------------
      &              , tSiM, tFeM, tMg2SiO4, tMgSiO3, tFe3O4
      &              , tAC, tSiO2D, tMgO, tFeS, tAl2O3
      &              , treforg, tvolorg, tH2Oice, iuseH2shield
+     &              , iH2shieldcustom, f_shield_custom
      &      )
 
 !           Compute dedot and HIdot, the rates of change of de and HI

--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -969,6 +969,7 @@ c     chunit = (1.60218e-12_DKIND)/(2._DKIND*uvel*uvel*mh)   ! 1 eV per H2 forme
      &              , tSiM, tFeM, tMg2SiO4, tMgSiO3, tFe3O4
      &              , tAC, tSiO2D, tMgO, tFeS, tAl2O3
      &              , treforg, tvolorg, tH2Oice, iuseH2shield
+     &              , iH2shieldcustom, f_shield_custom
      &      )
 
 !           Compute dedot and HIdot, the rates of change of de and HI
@@ -1329,7 +1330,8 @@ c     chunit = (1.60218e-12_DKIND)/(2._DKIND*uvel*uvel*mh)   ! 1 eV per H2 forme
      &                gasgr2a, gamma_isrf2a, grogra, idissHDI,
      &                kdissHDI, iionZ, kphCI, kphOI, idissZ, kdissCO,
      &                kdissOH, kdissH2O, iuseH2shield, iisrffield,
-     &                isrf_habing, ierror, j, k, iter, dom, comp1,
+     &                isrf_habing, iH2shieldcustom, f_shield_custom,
+     &                ierror, j, k, iter, dom, comp1,
      &                comp2, coolunit, tbase1, xbase1, chunit, dx_cgs,
      &                c_ljeans, indixe, t1, t2, logtem, tdef, dtit,
      &                p2d, tgas, tgasold, tdust, metallicity, dust2gas,
@@ -1808,6 +1810,7 @@ C                 endif
      &              , tSiM, tFeM, tMg2SiO4, tMgSiO3, tFe3O4
      &              , tAC, tSiO2D, tMgO, tFeS, tAl2O3
      &              , treforg, tvolorg, tH2Oice, iuseH2shield
+     &              , iH2shieldcustom, f_shield_custom
      &      )
 ! -------------------------------------------------------------------
 

--- a/src/clib/solve_rate_cool_g.F
+++ b/src/clib/solve_rate_cool_g.F
@@ -878,7 +878,15 @@ c     chunit = (1.60218e-12_DKIND)/(2._DKIND*uvel*uvel*mh)   ! 1 eV per H2 forme
      &              , gasgr2a, gamma_isrf2a
      &          )
 
-            if (ispecies .gt. 0) then
+            if (ispecies .eq. 0) then
+!        This is some basic book-keeping to ensure that itmask_tmp has
+!        sensible values when ispecies is 0
+!        -> There's room for optimization: when ispecies is 0, there is
+!           need to ever touch this variable. But, for now we focus on
+!           correct behavior before implementing this optimization
+              itmask_tmp = itmask
+
+            else
 
 !        Look-up rates as a function of temperature for 1D set of zones
 !         (maybe should add itmask to this call)

--- a/src/clib/step_rate_newton_raphson.F
+++ b/src/clib/step_rate_newton_raphson.F
@@ -75,7 +75,8 @@
      &                gasgr2a, gamma_isrf2a, grogra, idissHDI,
      &                kdissHDI, iionZ, kphCI, kphOI, idissZ, kdissCO,
      &                kdissOH, kdissH2O, iuseH2shield, iisrffield,
-     &                isrf_habing, ierror, j, k, iter, dom, comp1,
+     &                isrf_habing, iH2shieldcustom, f_shield_custom,
+     &                ierror, j, k, iter, dom, comp1,
      &                comp2, coolunit, tbase1, xbase1, chunit, dx_cgs,
      &                c_ljeans, indixe, t1, t2, logtem, tdef, dtit,
      &                p2d, tgas, tgasold, tdust, metallicity, dust2gas,
@@ -104,7 +105,7 @@
      &        idustfield, idustrec, igammah, ih2optical, iciecool,
      &        ithreebody, ih2cr, ihdcr, ndratec, clnew, iVheat, iMheat,
      &        iTfloor, iH2shield, iradshield, iradtrans, irt_honly,
-     &        imchem, igrgr, ipcont, iisrffield
+     &        imchem, igrgr, ipcont, iisrffield, iH2shieldcustom
 
       real*8 aye, temstart, temend, gamma, utim, uxyz, uaye, urho,
      &       utem, fh, z_solar, fgr, dtemstart, dtemend, clEleFra,
@@ -159,6 +160,10 @@
 !  Interstellar radiation field for dust heating
 
       R_PREC  isrf_habing(in,jn,kn)
+
+!  Custom H2 shielding factor
+
+      R_PREC f_shield_custom(in, jn, kn)
 
 !  Cooling tables (coolings rates as a function of temperature)
 
@@ -681,7 +686,7 @@
      & , imp_eng(i)
      & , idissHDI, kdissHDI(i,j,k), iionZ, kphCI(i,j,k), kphOI(i,j,k)
      & , idissZ, kdissCO(i,j,k), kdissOH(i,j,k), kdissH2O(i,j,k)
-     & , iuseH2shield
+     & , iuseH2shield, iH2shieldcustom, f_shield_custom(i,j,k)
      &   )
 
                     do jsp = 1, nsp
@@ -817,7 +822,7 @@
      & , imp_eng(i)
      & , idissHDI, kdissHDI(i,j,k), iionZ, kphCI(i,j,k), kphOI(i,j,k)
      & , idissZ, kdissCO(i,j,k), kdissOH(i,j,k), kdissH2O(i,j,k)
-     & , iuseH2shield
+     & , iuseH2shield, iH2shieldcustom, f_shield_custom(i,j,k)
      &   )
 
                       do isp = 1, nsp

--- a/src/python/examples/cooling_rate.py
+++ b/src/python/examples/cooling_rate.py
@@ -69,6 +69,9 @@ if __name__ == "__main__":
         my_chemistry.use_specific_heating_rate = 1
         my_chemistry.use_volumetric_heating_rate = 1
 
+    # max_iterations needs to be increased for the colder temperatures
+    my_chemistry.max_iterations = 4*10000
+
     # Set units
     my_chemistry.comoving_coordinates = 0 # proper units
     my_chemistry.a_units = 1.0


### PR DESCRIPTION
I finally tracked down the origin of the flaky tests python tests via valgrind

cooling_rate.py
----------------------

It turns out that the we weren't initializing `dust2gas` or `myisrf` at indices where `itmask_metal`  was false. This was a problem because Photo-electric heating of UV irradiated dust is currently implemented such that it only depends upon `itmask` rather than `itmask_metal`.
- In other words, the tests `cooling_rate.py` scripts were triggering cases where `itmask_metal` is false and `itmask` is true
- thus, when we add contributions of Photo-electric heating of UV irradiated dust to `edot`, we would be adding garbage unitialized values.

As I write up this explanation, I realize that an argument could definitely be made that we should only add photo-electric heating when `itmask_metal` is true. But, can circle back to that (atm, I'm focused on repeatable code rather than getting the physics exactly right)


cooling_cell.py
---------------------
While running cooling_cell.py under valgrind, I uncovered that we were using `itmask_tmp` without initializing it when `primordial_chemistry == 0`.

------------
I confirmed that the ``freefall.py`` tests don't produce any errors when run with valgrind.

This PR includes the change from #12, so it should be reviewed afterwards (if you prefer, I can split this into a separate PR, but that doesn't seem very necessary)
